### PR TITLE
fix a repo link

### DIFF
--- a/_posts/2019-05-08-CVC19.markdown
+++ b/_posts/2019-05-08-CVC19.markdown
@@ -17,7 +17,7 @@ The projects list, This is not the final rank.
 
 |Rank|TeamName|Team#|DemoVideo|SourceCode|
 |-------|-------|-------|-------|-------|
-1|B7b El-Cima|5|[youtube](https://youtu.be/HuqR4sw75ko)|[github](https://github.com/SuperMoody/b7b_el_cima.git)
+1|B7b El-Cima|5|[youtube](https://youtu.be/HuqR4sw75ko)|[github](https://github.com/SuperMoudy/b7b_el_cima.git)
 2|X-Team|42|[youtube](https://youtu.be/Ft0mwggR25U)|[github](https://github.com/diaaahmed850/Vision19)
 3|SitFit|66|[youtube](https://youtu.be/UXKte1Qf39A)|[github](https://github.com/SamuelFarid/SitFit)
 4|ScanLee|22|[youtube](https://www.youtube.com/watch?v=YwVEqtSxIM8&feature=youtu.be&fbclid=IwAR1r2SEXiNYrXbm8hGDTHM02FwrZL4-6bLZJZ_qO0xRcoB4I6h4fGv1UwR4)|[github](https://github.com/3omar3allam/salah-ly)


### PR DESCRIPTION
update b7b_el_cima repo link from:
https://github.com/SuperMoody.git
to
https://github.com/SuperMoudy.git